### PR TITLE
Explicitly disallow only one specific h5py version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='darc',
       install_requires=['numpy',
                         'astropy',
                         'pyyaml',
-                        'h5py<3',  # bug in 3.0 causes error on keras model load
+                        'h5py!=3.0.0',  # bug in 3.0 causes error on keras model load
                         'pytz',
                         'voevent-parse',
                         'scipy',


### PR DESCRIPTION
This fixes the install of h5py for python 3.9 and 3.10 in the CI